### PR TITLE
Use onnx proto directly instead of onnx helper functions

### DIFF
--- a/onnx_opcounter/onnx_opcounter.py
+++ b/onnx_opcounter/onnx_opcounter.py
@@ -11,8 +11,7 @@ def calculate_params(model: onnx.ModelProto) -> int:
 
     for onnx_w in onnx_weights:
         try:
-            weight = numpy_helper.to_array(onnx_w)
-            params += np.prod(weight.shape)
+            params += np.prod(onnx_w.dims)
         except Exception as _:
             pass
 


### PR DESCRIPTION
Creating np.array isn't required